### PR TITLE
[optimisation, n/a] updated deps, improved tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1369,9 +1369,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.1.0.tgz",
-      "integrity": "sha512-zILwX9/Ocz4SV2vX7ox85AsrAgXV3f2o2gpIicdMIOra48WYqgUnWNH/cR/iHtmD2Vb3dLSC3LiEJnS05Gkw7w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.2.0.tgz",
+      "integrity": "sha512-y0uWc/FRfrHhpPZCYflWC8aE0KRJRY04rdZVfl8cL3sEZmOYyaBdhdlQPjKZBnuRMyLVK+JUZr7HaZFClQiH4w==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "start": "node index.js",
     "backend": "docker-compose up -d amqp",
     "test": "npm run test:unit",
-    "test:integration": "find ./test/integration -name '*.test.js' | NODE_ENV=test xargs mocha --require ./test/integration/testHelper.js --bail",
-    "test:unit": "find ./test/unit -name '*.test.js' | NODE_ENV=test xargs mocha --require ./test/unit/testHelper.js",
+    "test:integration": "NODE_ENV=test mocha --require ./test/integration/testHelper.js --spec ./test/integration/**/*.test.js --bail",
+    "test:unit": "NODE_ENV=test mocha --require ./test/unit/testHelper.js --spec ./test/unit/**/*.test.js",
     "test:unit:cov": "find ./test/unit -name '*.test.js' | NODE_ENV=test xargs nyc mocha --require ./test/unit/testHelper.js",
-    "test:mutants": "NODE_ENV=test NODE_PATH=. npx stryker run"
+    "test:mutants": "NODE_ENV=test npx stryker run"
   },
   "dependencies": {
     "amqplib": "^0.5.3"
@@ -47,7 +47,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.16.0",
-    "eslint-config-prettier": "^4.1.0",
+    "eslint-config-prettier": "^4.2.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.17.2",
     "eslint-plugin-mocha": "^5.3.0",

--- a/stryker.conf.js
+++ b/stryker.conf.js
@@ -11,8 +11,8 @@ module.exports = function(config) {
     reporters: ['clear-text', 'progress'],
     testRunner: 'mocha',
     mochaOptions: {
-      files: ['test/unit/**/*.test.js'],
-      require: ['test/unit/testHelper.js']
+      spec: ['./test/unit/**/*.test.js'],
+      require: ['./test/unit/testHelper.js']
     },
     transpilers: [],
     testFramework: 'mocha',


### PR DESCRIPTION
* Pinned Stryker to 1.2 due to [a bug in how v1.3 runs tests](https://github.com/stryker-mutator/stryker/issues/1525).
* updated how tests are invoked
* coverage still invoked the old way due to [an issue with `nyc`](https://github.com/istanbuljs/nyc/issues/1091)
* improved tests to get 100% stryker coverage
